### PR TITLE
GA: Reviewed GA to let superadmin see dashboard

### DIFF
--- a/google-analytics-summary-widget.php
+++ b/google-analytics-summary-widget.php
@@ -41,7 +41,14 @@ class GoogleAnalyticsSummary
     function addDashboardWidget()
     {
         # Check if the user is an admin
+//XTEC ************ MODIFICAT - To let superadmin see GA dashboard
+//2015.06.06 @jcaballero
+        if (ga_current_user_is(get_option(key_ga_dashboard_role)) || is_super_admin(get_current_user_id()) ) {
+//************ ORIGINAL
+/*
         if (ga_current_user_is(get_option(key_ga_dashboard_role))) {
+*/
+//************ FI
             wp_add_dashboard_widget('google-analytics-summary', __('Google Analytics Summary', 'google-analyticator'), array(
                 $this,
                 'widget'


### PR DESCRIPTION
Per testejar la tasca, com a super admin crees un blog, afegeixes un administrador a aquest blog rol(administrador), elimines al superadmin d'aquest blog. Entres com administador al blog creat, configures el google analyticator. Finalment com a super admin entres al blog nou propietat del admin, via url al navegador i al tauler hauries de poder visualitzar les analítiques de google.

CHANGES.TXT: show google analytic view in super admin  session when goes to others  admin's  blogs.
